### PR TITLE
fix save and also add proper format to the default options similar to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ For Live `Demo` [(Expo Snack)](https://snack.expo.dev/@danish1658/react-native-d
 | arrowicon| JSX Element | Pass any JSX to this prop like Text, Image or Icon to show instead of chevron icon
 | closeicon| JSX Element | Pass any JSX to this prop like Text, Image or Icon to show instead of close icon
 | searchPlaceholder| String | Custom placeholder text for search TextInput
-| defaultOption| Object | Pass default selected option in key value pair
+| defaultOption| Object | Pass default selected option in key value pair for Select dropdown list
+| defaultOptions| Object | Pass default selected option in key value pair for MultiSelect dropdown list
 | fontFamily| string | Pass font name to apply globally on each text field of component
 | notFoundText| string | Pass your custom message if any search result returns empty
 | dropdownShown| boolean | Control your dropdown ( on & off ) state by changing its value to true or false
@@ -192,6 +193,33 @@ const App = () => {
       search={false} 
       boxStyles={{borderRadius:0}} //override default styles
       defaultOption={{ key:'1', value:'Jammu & Kashmir' }}   //default selected option
+    />
+  )
+
+};
+
+
+
+import { MultipleSelectList } from 'react-native-dropdown-select-list'
+
+const App = () => {
+
+  const [selected, setSelected] = React.useState([]);
+  
+  const data = [
+    {key:'1',value:'Jammu & Kashmir'},
+    {key:'2',value:'Gujrat'},
+    {key:'3',value:'Maharashtra'},
+    {key:'4',value:'Goa'},
+  ]
+
+  return(
+    <MultipleSelectList 
+      onSelect={() => alert(selected)}
+      setSelected={(val) => setSelected(val)} 
+      data={data} 
+      save="value"
+      defaultOptions={[ {key:'1', value:'Jammu & Kashmir' }, {key:'4', value:'Goa' }]}   //default selected options
     />
   )
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ const App = () => {
       onSelect={() => alert(selected)}
       setSelected={(val) => setSelected(val)} 
       data={data} 
-      save="value"
+      save="key"
       defaultOptions={[ {key:'1', value:'Jammu & Kashmir' }, {key:'4', value:'Goa' }]}   //default selected options
     />
   )

--- a/components/MultipleSelectList.tsx
+++ b/components/MultipleSelectList.tsx
@@ -28,7 +28,7 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
         dropdownTextStyles,
         maxHeight,
         data,
-        defaultOptions,
+        defaultOptions = [],
         searchicon = false,
         arrowicon = false,
         closeicon = false,

--- a/components/MultipleSelectList.tsx
+++ b/components/MultipleSelectList.tsx
@@ -28,7 +28,7 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
         dropdownTextStyles,
         maxHeight,
         data,
-        defaultOptions = [],
+        defaultOptions,
         searchicon = false,
         arrowicon = false,
         closeicon = false,
@@ -98,8 +98,8 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
     },[selectedval])
 
     React.useEffect(() => {
-        let defaultOptionsKeys=defaultOptions.map(({key}) => {return key});
-        let defaultOptionsValues=defaultOptions.map(({value}) => {return value});
+        let defaultOptionsKeys=defaultOptions?defaultOptions.map(({key}) => {return key}):[];
+        let defaultOptionsValues=ddefaultOptions?efaultOptions.map(({value}) => {return value}):[];
         if(!_firstRender && defaultOptions && oldOption.current != defaultOptionsKeys ){
             oldOption.current = defaultOptionsKeys;
             if(save === 'value'){

--- a/components/MultipleSelectList.tsx
+++ b/components/MultipleSelectList.tsx
@@ -98,11 +98,27 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
     },[selectedval])
 
     React.useEffect(() => {
-        if(defaultOptions && _firstRender){
-            setSelected(defaultOptions);
-            setSelectedVal(defaultOptions);
+        let defaultOptionsKeys=defaultOptions.map(({key}) => {return key});
+        let defaultOptionsValues=defaultOptions.map(({value}) => {return value});
+        if(!_firstRender && defaultOptions && oldOption.current != defaultOptionsKeys ){
+            oldOption.current = defaultOptionsKeys;
+            if(save === 'value'){
+                setSelected(defaultOptionsValues);
+            }else{
+                setSelected(defaultOptionsKeys);
+            }
+            setSelectedVal(defaultOptionsValues);
         }
-    })
+        if(defaultOptions && _firstRender && defaultOptionsKeys != undefined){  
+            oldOption.current = defaultOptionsKeys;
+            if(save === 'value'){
+                setSelected(defaultOptionsValues);
+            }else{
+                setSelected(defaultOptionsKeys);
+            }
+            setSelectedVal(defaultOptionsValues);
+        }  
+    },[defaultOptions])
 
     React.useEffect(() => {
         if(!_firstRender){


### PR DESCRIPTION
…that of default option

**Hi KoalaBear,**
Great Jobs for the first draft in this functionality which I need but upon trying to implement your code, I found that there are some issues where the owner might reject it, mainly:
1) The defaultOption implemented by original owner is in the form of {key:any, value:any}, however, the current implementation for for defaultOptions is in the form of ['valueA', 'valueB'].
2) It does not work with the save functionality. It will setselected to value instead of key even if I have set it to save='key'.

For above issues, I had corrected them and updated an example in README:
import { MultipleSelectList } from 'react-native-dropdown-select-list'
```
const App = () => {

  const [selected, setSelected] = React.useState([]);
  
  const data = [
    {key:'1',value:'Jammu & Kashmir'},
    {key:'2',value:'Gujrat'},
    {key:'3',value:'Maharashtra'},
    {key:'4',value:'Goa'},
  ]

  return(
    <MultipleSelectList 
      onSelect={() => alert(selected)}
      setSelected={(val) => setSelected(val)} 
      data={data} 
      save="key"
      defaultOptions={[ {key:'1', value:'Jammu & Kashmir' }, {key:'4', value:'Goa' }]}   //default selected options
    />
  )

};
```